### PR TITLE
fix: add build directory to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "files": [
     "dist",
     "asset",
-    "README.md"
+    "README.md",
+    "build"
   ],
   "author": "WPDS Support <wpds@washpost.com>",
   "license": "ISC",


### PR DESCRIPTION
Our sourcemaps use "build" directory for source files.