### PR TITLE
feat: add src to files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "types": "./asset/index.d.ts",
   "sideEffects": false,
   "files": [
+    "src",
     "dist",
     "asset",
     "README.md",


### PR DESCRIPTION
Update package json to allow exposing "src" at the package level, so svg assets can be imported as raw assets if needed