### PR TITLE
fix: remove clip path from post pulse

### DIFF
--- a/package.json
+++ b/package.json
@@ -921,6 +921,10 @@
     "./asset/postpulse": {
       "import": "./asset/postpulse.mjs",
       "require": "./asset/postpulse.js"
+    },
+    "./asset/": {
+      "import": "./asset/.mjs",
+      "require": "./asset/.js"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -921,10 +921,6 @@
     "./asset/postpulse": {
       "import": "./asset/postpulse.mjs",
       "require": "./asset/postpulse.js"
-    },
-    "./asset/": {
-      "import": "./asset/.mjs",
-      "require": "./asset/.js"
     }
   }
 }

--- a/src/postpulse.svg
+++ b/src/postpulse.svg
@@ -1,4 +1,4 @@
-<svg width="500" height="375" viewBox="0 0 500 375" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 500 375" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M250 0L0 250H250V0Z" fill="#2165AD"/>
 <path d="M250 375V125H500L250 375Z" fill="#CE2027"/>
 </svg>

--- a/src/postpulse.svg
+++ b/src/postpulse.svg
@@ -1,11 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 500 375">
-  <g clip-path="url(#a)">
-    <path fill="#CE2027" d="M250 375V125h250L250 375Z"/>
-    <path fill="#2165AD" d="M250 0v250H0L250 0Z"/>
-  </g>
-  <defs>
-    <clipPath id="a">
-      <path fill="#fff" d="M0 0h500v375H0z"/>
-    </clipPath>
-  </defs>
+<svg width="500" height="375" viewBox="0 0 500 375" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M250 0L0 250H250V0Z" fill="#2165AD"/>
+<path d="M250 375V125H500L250 375Z" fill="#CE2027"/>
 </svg>


### PR DESCRIPTION
Remove the clip path that was used in the post pulse. It was causing rendering issues with other assets that have clip path in our repo. 