### PR TITLE
fix: package export bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -922,10 +922,6 @@
       "import": "./asset/postpulse.mjs",
       "require": "./asset/postpulse.js"
     },
-    "./asset/": {
-      "import": "./asset/.mjs",
-      "require": "./asset/.js"
-    },
     "./asset/crossed-swords": {
       "import": "./asset/crossed-swords.mjs",
       "require": "./asset/crossed-swords.js"

--- a/scripts/exports.mjs
+++ b/scripts/exports.mjs
@@ -1,5 +1,5 @@
 import fs from "fs/promises";
-import packageJson from "../package.json" assert { type: "json" };
+import packageJson from "../package.json" with { type: "json" };
 
 const files = await fs.readdir("src");
 


### PR DESCRIPTION
A couple of users have flagged that when importing icons they get the following error:
```
Error parsing package.json file
invalid exports field value "./asset/.js" for key "./asset/": folder exports must end with "/"
```

and when removing this block from `package.json`, the error goes away. It seems that it was not pointing to an actual file.
```
925  "./asset/": {
926    "import": "./asset/.mjs",
927    "require": "./asset/.js"
928  },
```
